### PR TITLE
dracut.sh: check for logfile (--logfile option) and create it if necessa...

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -803,6 +803,12 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 # eliminate IFS hackery when messing with fw_dir
 fw_dir=${fw_dir//:/ }
 
+if [[ ! -f $logfile ]];then
+    if [[ ! `touch $logfile > /dev/null 2>&1` ]];then
+        printf "%s\n" "dracut: touch $logfile failed. Couldn't create logfile."
+    fi
+fi
+
 # handle compression options.
 [[ $compress ]] || compress="gzip"
 case $compress in


### PR DESCRIPTION
dracut.sh: check for logfile (--logfile option) and create it if necessary

If a logfile is passed to dracut via --logfile option and doesn't
exist, dracut doesn't create it and logs nothing. Instead, dracut
should try to touch the file and print a warning if creating fails.

References: bnc#892191
