### PR TITLE
98systemd/rootfs-generator: Use builtins instead of 'grep' (bnc#897252)

### DIFF
--- a/modules.d/98systemd/rootfs-generator.sh
+++ b/modules.d/98systemd/rootfs-generator.sh
@@ -94,7 +94,8 @@ esac
 
 if [ "${root%%:*}" = "block" ]; then
    generator_wait_for_dev "${root#block:}" "$RDRETRY"
-   grep -q 'root=' /proc/cmdline || generator_mount_rootfs "${root#block:}" "$(getarg rootfstype=)" "$(getarg rootflags=)"
+   cmdline=$(</proc/cmdline)
+   test "$cmdline" = "${cmdline#*root=}" && generator_mount_rootfs "${root#block:}" "$(getarg rootfstype=)" "$(getarg rootflags=)"
 fi
 
 exit 0


### PR DESCRIPTION
Signed-off-by: Julian Wolf juwolf@suse.de
