### PR TITLE
10i18n/module-setup.sh: Check $FONT_MAP also without file ending

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -198,7 +198,12 @@ install() {
         if [[ ${FONT_MAP} ]]
         then
             FONT_MAP=${FONT_MAP%.trans}
-            inst_simple ${kbddir}/consoletrans/${FONT_MAP}.trans
+            if [ -f "${FONT_MAP}".trans ]; then
+                inst_simple ${kbddir}/consoletrans/${FONT_MAP}.trans
+            else if [ -f "$FONT_MAP" ]; then
+                inst_simple ${kbddir}/consoletrans/${FONT_MAP}
+                fi
+            fi
         fi
 
         if [[ ${FONT_UNIMAP} ]]


### PR DESCRIPTION
 For $FONT_MAP also check whether file exists without .trans ending (bnc#904533)

Signed-off-by: Julian Wolf juwolf@suse.de
