### PR TITLE
dracut.sh: Instead of blindly substituting %-i/--include in all paramete...

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -305,11 +305,17 @@ dropindirs_sort()
 rearrange_params()
 {
     # Workaround -i, --include taking 2 arguments
-    set -- "${@/--include/++include}"
-
-    # This prevents any long argument ending with "-i"
-    # -i, like --opt-i but I think we can just prevent that
-    set -- "${@/%-i/++include}"
+    COUNTER=0
+    for var in "$@"; do
+        if [ "$var" = "-i" ] || [ "$var" = "--include" ]; then
+            if [ $COUNTER -eq 0 ]; then
+                set -- "++include" "${@:2}"
+            else
+                set -- "${@:1:$COUNTER}" "++include" "${@:$((COUNTER+2))}"
+            fi
+        fi
+        (( COUNTER++ ))
+    done
 
     TEMP=$(unset POSIXLY_CORRECT; getopt \
         -o "a:m:o:d:I:k:c:L:fvqlHhMN" \


### PR DESCRIPTION
...rs

(which also has effect on the image name ending with -i) iterate over all
parameters and only substitute single "-i"/"--include" parameters. (bnc#908452)

Signed-off-by: Julian Wolf <juwolf@suse.de>